### PR TITLE
Add a basic end-to-end test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,18 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+        env:
+          discovery.type: single-node
+        options: >-
+          --health-cmd "curl http://localhost:9200/_cluster/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+        ports:
+        - 9200:9200
     strategy:
       matrix:
         python:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,5 +47,14 @@ Documentation = "https://django-rest-search.readthedocs.io/"
 [tool.coverage.run]
 source = ["rest_search"]
 
+[tool.ruff.lint]
+select = [
+    "E",  # pycodestyle
+    "F",  # Pyflakes
+    "W",  # pycodestyle
+    "I",  # isort
+    "T20",  # flake8-print
+]
+
 [tool.setuptools.dynamic]
 version = {attr = "rest_search.__version__"}

--- a/tests/celeryconfig.py
+++ b/tests/celeryconfig.py
@@ -1,0 +1,1 @@
+task_always_eager = True

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -2,7 +2,7 @@
 
 from rest_framework import serializers
 
-from tests.models import Author, Book, Unsupported
+from tests.models import Author, Book, Tag, Unsupported
 
 
 class AuthorSerializer(serializers.ModelSerializer):
@@ -12,7 +12,9 @@ class AuthorSerializer(serializers.ModelSerializer):
 
 
 class BookSerializer(serializers.ModelSerializer):
-    tags = serializers.StringRelatedField(many=True)
+    tags = serializers.SlugRelatedField(
+        many=True, queryset=Tag.objects.all(), slug_field="slug"
+    )
 
     class Meta:
         model = Book

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -20,3 +20,5 @@ REST_SEARCH_CONNECTIONS = {"default": {"HOST": "es.example.com"}}
 ROOT_URLCONF = "tests.urls"
 
 SECRET_KEY = "_%2pegfm%-&32ekj_+aqr468-*8lkt7zbeyl)*0#f-@56#$k_)"
+
+TEST_REQUEST_DEFAULT_FORMAT = "json"

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,123 @@
+import time
+
+from celery import Celery
+from django.test import TestCase, override_settings
+from rest_framework.test import APIClient
+
+from rest_search.decorators import flush_updates
+from rest_search.tasks import create_index, delete_index
+from tests.models import Tag
+
+app = Celery()
+app.config_from_object("tests.celeryconfig")
+
+
+@override_settings(
+    REST_SEARCH_CONNECTIONS={
+        "default": {
+            "HOST": "localhost",
+        }
+    },
+)
+class EndToEndTest(TestCase):
+    client_class = APIClient
+
+    def setUp(self):
+        create_index()
+
+        Tag.objects.create(slug="foo")
+        Tag.objects.create(slug="bar")
+        Tag.objects.create(slug="qux")
+
+    def tearDown(self):
+        delete_index()
+
+    @flush_updates
+    def test_book(self):
+        # Create books.
+        response = self.client.post(
+            "/books", {"tags": ["foo", "bar"], "title": "Some book"}
+        )
+        self.assertEqual(response.status_code, 201)
+        book_pk = response.data["id"]
+
+        response = self.client.post("/books", {"tags": ["qux"], "title": "Other book"})
+        self.assertEqual(response.status_code, 201)
+
+        # Allow time for indexing.
+        time.sleep(1)
+
+        # Search books.
+        response = self.client.get("/books/search")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "count": 2,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {"tags": ["foo", "bar"], "title": "Some book"},
+                    {"tags": ["qux"], "title": "Other book"},
+                ],
+            },
+        )
+
+        response = self.client.get("/books/search", {"tags": "foo"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [{"tags": ["foo", "bar"], "title": "Some book"}],
+            },
+        )
+
+        # Update book.
+        response = self.client.put(
+            f"/books/{book_pk}", {"tags": ["foo"], "title": "Some book (changed)"}
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Allow time for indexing.
+        time.sleep(1)
+
+        # Search books.
+        response = self.client.get("/books/search")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "count": 2,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {"tags": ["qux"], "title": "Other book"},
+                    {"tags": ["foo"], "title": "Some book (changed)"},
+                ],
+            },
+        )
+
+        # Delete book.
+        response = self.client.delete(f"/books/{book_pk}")
+        self.assertEqual(response.status_code, 204)
+
+        # Allow time for indexing.
+        time.sleep(1)
+
+        # Search books.
+        response = self.client.get("/books/search")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data,
+            {
+                "count": 1,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {"tags": ["qux"], "title": "Other book"},
+                ],
+            },
+        )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 
 from django.urls import path
+from rest_framework.routers import SimpleRouter
 
 from tests import views
 
+router = SimpleRouter(trailing_slash=False)
+router.register("authors", views.AuthorViewSet, basename="author")
+router.register("books", views.BookViewSet, basename="book")
+
 urlpatterns = [
-    path("books", views.BookCreate.as_view()),
     path("books/search", views.BookSearch.as_view()),
     path("books/search_sorted", views.BookSearchSorted.as_view()),
-]
+] + router.urls

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,14 +1,21 @@
 # -*- coding: utf-8 -*-
 
-from rest_framework.generics import CreateAPIView
+from rest_framework import viewsets
 
 from rest_search.views import SearchAPIView
 from tests.forms import BookSearchForm
 from tests.indexers import BookIndexer
-from tests.serializers import BookSerializer
+from tests.models import Author, Book
+from tests.serializers import AuthorSerializer, BookSerializer
 
 
-class BookCreate(CreateAPIView):
+class AuthorViewSet(viewsets.ModelViewSet):
+    queryset = Author.objects.all()
+    serializer_class = AuthorSerializer
+
+
+class BookViewSet(viewsets.ModelViewSet):
+    queryset = Book.objects.all()
     serializer_class = BookSerializer
 
 


### PR DESCRIPTION
Until now, all our tests mock the calls to ElasticSearch. This is not sufficient to ensure requests work as expected.