### PR TITLE
feat(connection): let botocore extract aws credentials, do not use sessions

### DIFF
--- a/src/rest_search/__init__.py
+++ b/src/rest_search/__init__.py
@@ -3,7 +3,7 @@
 from threading import local
 
 from aws_requests_auth.aws_auth import AWSRequestsAuth
-from botocore.session import Session
+from aws_requests_auth.boto_utils import BotoAWSRequestsAuth
 from django.conf import settings
 from opensearchpy import OpenSearch, RequestsHttpConnection
 
@@ -58,14 +58,8 @@ class ConnectionHandler(object):
                 aws_service="es",
             )
         elif "AWS_REGION" in config:
-            session = Session()
-            creds = session.get_credentials().get_frozen_credentials()
-
             kwargs["connection_class"] = RequestsHttpConnection
-            kwargs["http_auth"] = AWSRequestsAuth(
-                aws_access_key=creds.access_key,
-                aws_secret_access_key=creds.secret_key,
-                aws_token=creds.token,
+            kwargs["http_auth"] = BotoAWSRequestsAuth(
                 aws_host=config["HOST"],
                 aws_region=config["AWS_REGION"],
                 aws_service="es",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 
@@ -42,15 +42,7 @@ class ConnectionTest(TestCase):
         }
     )
     @patch("rest_search.OpenSearch")
-    @patch("rest_search.Session")
-    def test_aws_role_auth(self, mock_session, mock_opensearch):
-        mock_creds = Mock(
-            access_key="mock-access-key",
-            secret_key="mock-secret-key",
-            token="mock-token",
-        )
-        mock_session.return_value.get_credentials.return_value.get_frozen_credentials.return_value = mock_creds
-
+    def test_aws_role_auth(self, mock_opensearch):
         es = connections["default"]
         self.assertIsNotNone(es)
 


### PR DESCRIPTION
sessions will expire, so let botocore extract aws credentials from AMI role

https://github.com/DavidMuller/aws-requests-auth/blob/master/README.md#using-boto-to-automatically-gather-aws-credentials



