### PR TITLE
Pass arguments as keyword arguments

### DIFF
--- a/src/rest_search/indexers.py
+++ b/src/rest_search/indexers.py
@@ -50,12 +50,12 @@ class Indexer(object):
         return map(map_result_item, results)
 
     def scan(self, **kwargs):
-        es = get_opensearch(self)
-        return scan(es, index=self.index, **kwargs)
+        client = get_opensearch(self)
+        return scan(client=client, index=self.index, **kwargs)
 
     def search(self, **kwargs):
-        es = get_opensearch(self)
-        return es.search(index=self.index, **kwargs)
+        client = get_opensearch(self)
+        return client.search(index=self.index, **kwargs)
 
 
 def _get_registered():

--- a/src/rest_search/tasks.py
+++ b/src/rest_search/tasks.py
@@ -25,8 +25,8 @@ def delete_index():
     Deletes the OpenSearch indices.
     """
     for indexer in _get_registered():
-        es = get_opensearch(indexer)
-        es.indices.delete(index=indexer.index, ignore=404)
+        client = get_opensearch(indexer)
+        client.indices.delete(index=indexer.index, ignore=404)
 
 
 @shared_task
@@ -71,14 +71,14 @@ def _create_index(indexer):
     if indexer.mappings is not None:
         body["mappings"] = indexer.mappings
 
-    es = get_opensearch(indexer)
-    if not es.indices.exists(indexer.index):
+    client = get_opensearch(indexer)
+    if not client.indices.exists(index=indexer.index):
         logger.info("Creating index %s" % indexer.index)
-        es.indices.create(index=indexer.index, body=body)
+        client.indices.create(index=indexer.index, body=body)
 
 
 def _delete_items(indexer, pks):
-    es = get_opensearch(indexer)
+    client = get_opensearch(indexer)
 
     def mapper(pk):
         return {
@@ -87,14 +87,14 @@ def _delete_items(indexer, pks):
             "_op_type": "delete",
         }
 
-    bulk(es, map(mapper, pks), raise_on_error=False)
+    bulk(client=client, actions=map(mapper, pks), raise_on_error=False)
 
 
 def _index_items(indexer, pks):
     """
     Primary keys are manipulated in their native type (int, UUID).
     """
-    es = get_opensearch(indexer)
+    client = get_opensearch(indexer)
     seen_pks = set()
 
     def bulk_mapper(block_size=1000):
@@ -112,7 +112,7 @@ def _index_items(indexer, pks):
                     "_source": item,
                 }
 
-    bulk(es, bulk_mapper())
+    bulk(client=client, actions=bulk_mapper())
     return seen_pks
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -14,7 +14,7 @@ class MockBulk(object):
     def __init__(self):
         self.actions = []
 
-    def __call__(self, es, actions, raise_on_error=True):
+    def __call__(self, client, actions, raise_on_error=True):
         self.actions.extend(actions)
 
 
@@ -41,8 +41,8 @@ class TasksTest(TestCase):
         self.assertEqual(
             mock_exists.mock_calls,
             [
-                mock.call("author"),
-                mock.call("book"),
+                mock.call(index="author"),
+                mock.call(index="book"),
             ],
         )
         self.assertEqual(
@@ -93,8 +93,8 @@ class TasksTest(TestCase):
         self.assertEqual(
             mock_exists.mock_calls,
             [
-                mock.call("author"),
-                mock.call("book"),
+                mock.call(index="author"),
+                mock.call(index="book"),
             ],
         )
         mock_create.assert_not_called()
@@ -185,7 +185,7 @@ class TasksTest(TestCase):
 
         mock_bulk.side_effect = MockBulk()
 
-        def mock_scan(_es, *, index, **kwargs):
+        def mock_scan(*, client, index, **kwargs):
             # nothing in index
             return []
 
@@ -211,7 +211,7 @@ class TasksTest(TestCase):
 
         mock_bulk.side_effect = MockBulk()
 
-        def mock_scan(_es, *, index, **kwargs):
+        def mock_scan(*, client, index, **kwargs):
             return {
                 "author": [],
                 "book": [
@@ -242,7 +242,7 @@ class TasksTest(TestCase):
 
         mock_bulk.side_effect = MockBulk()
 
-        def mock_scan(_es, *, index, **kwargs):
+        def mock_scan(*, client, index, **kwargs):
             return {
                 "author": [
                     {
@@ -295,7 +295,7 @@ class TasksTest(TestCase):
 
         mock_bulk.side_effect = MockBulk()
 
-        def mock_scan(_es, *, index, **kwargs):
+        def mock_scan(*, client, index, **kwargs):
             return {
                 "author": [],
                 "book": [


### PR DESCRIPTION
opensearch-py 3.x starts enforcing keyword-only arguments for most APIs.