### PR TITLE
Allow opensearch-py 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "aws-requests-auth>=0.3.0",
     "botocore",
-    "opensearch-py>=2.0.0,<3.0.0",
+    "opensearch-py>=2.0.0,<4.0.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Our code is compatible with both opensearch-py 2.x and opensearch-py 3.x, as we now use keyword arguments.